### PR TITLE
Unquote

### DIFF
--- a/common/devpi_common/url.py
+++ b/common/devpi_common/url.py
@@ -1,13 +1,14 @@
-
 import sys
 import posixpath
 from devpi_common.types import cached_property, ensure_unicode, parse_hash_spec
 from requests.models import parse_url
 
 if sys.version_info >= (3, 0):
-    from urllib.parse import urlparse, urlunsplit, urljoin
+    from urllib.parse import urlparse, urlunsplit, urljoin, unquote
 else:
     from urlparse import urlparse, urlunsplit, urljoin
+    from urllib import unqote
+
 
 def _joinpath(url, args, asdir=False):
     new = url
@@ -17,6 +18,7 @@ def _joinpath(url, args, asdir=False):
     if asdir:
         new = new.rstrip("/") + "/"
     return new
+
 
 class URL:
     def __init__(self, url="", *args, **kwargs):
@@ -121,11 +123,11 @@ class URL:
 
     @property
     def basename(self):
-        return posixpath.basename(self._parsed.path)
+        return posixpath.basename(unqote(self._parsed.path))
 
     @property
     def parentbasename(self):
-        return posixpath.basename(posixpath.dirname(self._parsed.path))
+        return posixpath.basename(posixpath.dirname(unqote(self._parsed.path)))
 
     @property
     def eggfragment(self):
@@ -193,4 +195,3 @@ class URL:
         """ return url from canonical relative path. """
         scheme, netlocpath = relpath.split("/", 1)
         return cls(scheme + "://" + netlocpath)
-

--- a/common/devpi_common/url.py
+++ b/common/devpi_common/url.py
@@ -7,7 +7,7 @@ if sys.version_info >= (3, 0):
     from urllib.parse import urlparse, urlunsplit, urljoin, unquote
 else:
     from urlparse import urlparse, urlunsplit, urljoin
-    from urllib import unqote
+    from urllib import unquote
 
 
 def _joinpath(url, args, asdir=False):
@@ -123,11 +123,11 @@ class URL:
 
     @property
     def basename(self):
-        return posixpath.basename(unqote(self._parsed.path))
+        return posixpath.basename(unquote(self._parsed.path))
 
     @property
     def parentbasename(self):
-        return posixpath.basename(posixpath.dirname(unqote(self._parsed.path)))
+        return posixpath.basename(posixpath.dirname(unquote(self._parsed.path)))
 
     @property
     def eggfragment(self):

--- a/server/devpi_server/filestore.py
+++ b/server/devpi_server/filestore.py
@@ -10,6 +10,7 @@ from wsgiref.handlers import format_date_time
 import os
 import py
 import re
+import sys
 from devpi_common.types import cached_property, parse_hash_spec
 from .log import threadlog
 
@@ -63,8 +64,8 @@ class FileStore:
             dirname = re.sub('[^a-zA-Z0-9_.-]', '_', dirname)
             key = self.keyfs.PYPIFILE_NOMD5(
                 user=user, index=index,
-                dirname=unqote(dirname),
-                basename=unqote(parts[-1]))
+                dirname=unquote(dirname),
+                basename=unquote(parts[-1]))
         entry = FileEntry(self.xom, key, readonly=False)
         entry.url = link.geturl_nofragment().url
         entry.eggfragment = link.eggfragment

--- a/server/devpi_server/filestore.py
+++ b/server/devpi_server/filestore.py
@@ -13,6 +13,12 @@ import re
 from devpi_common.types import cached_property, parse_hash_spec
 from .log import threadlog
 
+
+if sys.version_info >= (3, 0):
+    from urllib.parse import unquote
+else:
+    from urllib import unquote
+
 log = threadlog
 _nodefault = object()
 
@@ -57,8 +63,8 @@ class FileStore:
             dirname = re.sub('[^a-zA-Z0-9_.-]', '_', dirname)
             key = self.keyfs.PYPIFILE_NOMD5(
                 user=user, index=index,
-                dirname=dirname,
-                basename=parts[-1])
+                dirname=unqote(dirname),
+                basename=unqote(parts[-1]))
         entry = FileEntry(self.xom, key, readonly=False)
         entry.url = link.geturl_nofragment().url
         entry.eggfragment = link.eggfragment


### PR DESCRIPTION
Solves problem with quoted `+` and `!` in path names.
Both `!` and `+` are valid characters in version specifier per PEP440 (`!` separates epoch, `+` separates local part). 

Before:

```reading remote: https://host/foo-1.2.3%2Bvendor-py2-none-any.whl, target root/a_mirror/+e/host/foo-1.2.3%2Bvendor-py2-none-any.whl```

Saving as `foo-1.2.3%2Bvendor-py2-none-any.whl` was subsequently causing `file not found` error when trying to access `foo-1.2.3+vendor-py2-none-any.whl

After:
```reading remote: https://host/foo-1.2.3%2Bvendor-py2-none-any.whl, target root/a_mirror/+e/host/foo-1.2.3+vendor-py2-none-any.whl```